### PR TITLE
include the tzdata data using go tags

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -27,6 +27,8 @@ builds:
   - windows
   - linux
   ignore: []
+  tags:
+  - timetzdata
   ldflags:
   - -X github.com/pulumi/pulumi-pagerduty/provider/v3/pkg/version.Version={{.Tag}}
   main: ./cmd/pulumi-resource-pagerduty/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,8 @@ builds:
   - windows
   - linux
   ignore: []
+  tags:
+  - timetzdata
   ldflags:
   - -X
     github.com/pulumi/pulumi-pagerduty/provider/v3/pkg/version.Version={{.Tag}}


### PR DESCRIPTION
The upstream provider builds the provider with the `timetzdata` flag so that users get the the timezone data even if they don't meet the prerequisites as defined in the `time` package: https://pkg.go.dev/time#LoadLocation

This adds the timetzdata flag so that Pulumi users aren't affected too

Fixes #219 

Note: we likely want to get these changes into ci-mgmt so they don't get overridden