### PR TITLE
Ensure time/tzdata is imported and tzdata is embbedded

### DIFF
--- a/examples/misc_test.go
+++ b/examples/misc_test.go
@@ -1,0 +1,57 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"runtime"
+	"testing"
+)
+
+func TestEmbeddedTZData(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("Checking for embedded tzdata is only supported on GOOS=linux and GOOS=darwin builds")
+	}
+	bin := "../bin/pulumi-resource-pagerduty"
+	f, err := os.Open(bin)
+	if os.IsNotExist(err) {
+		t.Errorf("built provider not found: %q, try running make provider first", bin)
+		t.FailNow()
+	}
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	t.Cleanup(func() {
+		err := f.Close()
+		if err != nil {
+			t.Error(err)
+			t.FailNow()
+		}
+	})
+	// Heuristic to detect embedded tzdata:
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.20.5:src/time/tzdata/zipdata.go
+	searchString := "Africa/BrazzavilleTZif2"
+	matched, err := regexp.MatchReader(searchString, bufio.NewReader(f))
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if !matched {
+		t.Errorf("%s does not contain %q, are you sure `time/tzdata` is imported?", bin, searchString)
+	}
+}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -20,6 +20,7 @@ import (
 	_ "embed"
 	"path/filepath"
 	"strings"
+	// tzdata is used to ensure the provider works when deployed to OS-es that do not have it
 	_ "time/tzdata"
 	"unicode"
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -20,6 +20,7 @@ import (
 	_ "embed"
 	"path/filepath"
 	"strings"
+	_ "time/tzdata"
 	"unicode"
 
 	"github.com/PagerDuty/terraform-provider-pagerduty/pagerduty"


### PR DESCRIPTION
This helps the provider resolve timezones when deployed on systems without global tzdata installed.

Fixes https://github.com/pulumi/pulumi-pagerduty/issues/219

Like the original https://github.com/pulumi/pulumi-pagerduty/pull/220 this makes sure timezone data is embedded in the provider binary so it works regardless of whether the timezone data is available on the OS. Small improvements over the original PR: the fix goes int he source code and not in the goreleaser files so:

- ci-mgmt is not in play
- local/goreleaser build discrepancy is not in play
- a quickie test is added to double check that the tzdata is indeed embedded
