### PR TITLE
DocsEdits for pagerduty.Service

### DIFF
--- a/provider/cmd/pulumi-resource-pagerduty/schema.json
+++ b/provider/cmd/pulumi-resource-pagerduty/schema.json
@@ -2469,7 +2469,7 @@
                 },
                 "timeout": {
                     "type": "integer",
-                    "description": "Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.\n\n\nYou may specify one optional `incident_urgency_rule` block configuring what urgencies to use.\nYour PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.\nThe block contains the following arguments:\n"
+                    "description": "Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.\n"
                 }
             },
             "type": "object",
@@ -2813,17 +2813,20 @@
         "pagerduty:index/ServiceIncidentUrgencyRule:ServiceIncidentUrgencyRule": {
             "properties": {
                 "duringSupportHours": {
-                    "$ref": "#/types/pagerduty:index/ServiceIncidentUrgencyRuleDuringSupportHours:ServiceIncidentUrgencyRuleDuringSupportHours"
+                    "$ref": "#/types/pagerduty:index/ServiceIncidentUrgencyRuleDuringSupportHours:ServiceIncidentUrgencyRuleDuringSupportHours",
+                    "description": "Incidents' urgency during support hours.\n"
                 },
                 "outsideSupportHours": {
-                    "$ref": "#/types/pagerduty:index/ServiceIncidentUrgencyRuleOutsideSupportHours:ServiceIncidentUrgencyRuleOutsideSupportHours"
+                    "$ref": "#/types/pagerduty:index/ServiceIncidentUrgencyRuleOutsideSupportHours:ServiceIncidentUrgencyRuleOutsideSupportHours",
+                    "description": "Incidents' urgency outside support hours.\n"
                 },
                 "type": {
                     "type": "string",
-                    "description": "The type of object. The value returned will be `service`. Can be used for passing to a service dependency.\n"
+                    "description": "The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).\n"
                 },
                 "urgency": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.\n"
                 }
             },
             "type": "object",
@@ -3034,14 +3037,16 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/types/pagerduty:index/ServiceScheduledActionAt:ServiceScheduledActionAt"
-                    }
+                    },
+                    "description": "A block representing when the scheduled action will occur.\n"
                 },
                 "toUrgency": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).\n"
                 },
                 "type": {
                     "type": "string",
-                    "description": "The type of object. The value returned will be `service`. Can be used for passing to a service dependency.\n"
+                    "description": "The type of scheduled action. Currently, this must be set to `urgency_change`.\n"
                 }
             },
             "type": "object"
@@ -3065,20 +3070,24 @@
                     "type": "array",
                     "items": {
                         "type": "integer"
-                    }
+                    },
+                    "description": "Array of days of week as integers. `1` to `7`, `1` being\nMonday and `7` being Sunday.\n"
                 },
                 "endTime": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The support hours' ending time of day.\n"
                 },
                 "startTime": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The support hours' starting time of day.\n"
                 },
                 "timeZone": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The time zone for the support hours.\n"
                 },
                 "type": {
                     "type": "string",
-                    "description": "The type of object. The value returned will be `service`. Can be used for passing to a service dependency.\n"
+                    "description": "The type of support hours. Can be `fixed_time_per_day`.\n"
                 }
             },
             "type": "object"

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -15,6 +15,7 @@
 package pagerduty
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"path/filepath"
@@ -84,6 +85,7 @@ func Provider() tfbridge.ProviderInfo {
 		GitHubOrg:   "PagerDuty",
 		Repository:  "https://github.com/pulumi/pulumi-pagerduty",
 		Version:     version.Version,
+		DocRules:    &tfbridge.DocRuleInfo{EditRules: docEditRules},
 		Config: map[string]*tfbridge.SchemaInfo{
 			"skip_credentials_validation": {
 				Type: "boolean",
@@ -217,6 +219,33 @@ func Provider() tfbridge.ProviderInfo {
 	prov.SetAutonaming(255, "-")
 
 	return prov
+}
+
+func docEditRules(defaults []tfbridge.DocsEdit) []tfbridge.DocsEdit {
+	return append(defaults, tfbridge.DocsEdit{
+		Path: "service.html.markdown",
+		Edit: func(_ string, content []byte) ([]byte, error) {
+
+			content = bytes.Replace(content,
+				[]byte("You may specify one optional `incident_urgency_rule` block configuring what urgencies to "+
+					"use.\nYour PagerDuty account must have the `urgencies` ability to assign an incident urgency "+
+					"rule.\nThe block contains the following arguments:"),
+				[]byte("The `incident_urgency_rule` block contains the following arguments:"),
+				1)
+			content = bytes.Replace(content,
+				[]byte("When using `type = \"use_support_hours\"` in `incident_urgency_rule` you must specify "+
+					"exactly one (otherwise optional) `support_hours` block.\nYour PagerDuty account must have the "+
+					"`service_support_hours` ability to assign support hours."),
+				[]byte("The `support_hours` block contains the following arguments:"),
+				1)
+			content = bytes.Replace(content,
+				[]byte("A `scheduled_actions` block is required when using `type = \"use_support_hours\"` in "+
+					"`incident_urgency_rule`.\n\nThe block contains the following arguments:"),
+				[]byte("The `scheduled_actions` block contains the following arguments:"),
+				1)
+			return content, nil
+		},
+	})
 }
 
 //go:embed cmd/pulumi-resource-pagerduty/bridge-metadata.json

--- a/sdk/dotnet/Inputs/ServiceAutoPauseNotificationsParametersArgs.cs
+++ b/sdk/dotnet/Inputs/ServiceAutoPauseNotificationsParametersArgs.cs
@@ -20,11 +20,6 @@ namespace Pulumi.Pagerduty.Inputs
 
         /// <summary>
         /// Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-        /// 
-        /// 
-        /// You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
-        /// Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-        /// The block contains the following arguments:
         /// </summary>
         [Input("timeout")]
         public Input<int>? Timeout { get; set; }

--- a/sdk/dotnet/Inputs/ServiceAutoPauseNotificationsParametersGetArgs.cs
+++ b/sdk/dotnet/Inputs/ServiceAutoPauseNotificationsParametersGetArgs.cs
@@ -20,11 +20,6 @@ namespace Pulumi.Pagerduty.Inputs
 
         /// <summary>
         /// Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-        /// 
-        /// 
-        /// You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
-        /// Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-        /// The block contains the following arguments:
         /// </summary>
         [Input("timeout")]
         public Input<int>? Timeout { get; set; }

--- a/sdk/dotnet/Inputs/ServiceIncidentUrgencyRuleArgs.cs
+++ b/sdk/dotnet/Inputs/ServiceIncidentUrgencyRuleArgs.cs
@@ -12,18 +12,27 @@ namespace Pulumi.Pagerduty.Inputs
 
     public sealed class ServiceIncidentUrgencyRuleArgs : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// Incidents' urgency during support hours.
+        /// </summary>
         [Input("duringSupportHours")]
         public Input<Inputs.ServiceIncidentUrgencyRuleDuringSupportHoursArgs>? DuringSupportHours { get; set; }
 
+        /// <summary>
+        /// Incidents' urgency outside support hours.
+        /// </summary>
         [Input("outsideSupportHours")]
         public Input<Inputs.ServiceIncidentUrgencyRuleOutsideSupportHoursArgs>? OutsideSupportHours { get; set; }
 
         /// <summary>
-        /// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        /// The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).
         /// </summary>
         [Input("type", required: true)]
         public Input<string> Type { get; set; } = null!;
 
+        /// <summary>
+        /// The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.
+        /// </summary>
         [Input("urgency")]
         public Input<string>? Urgency { get; set; }
 

--- a/sdk/dotnet/Inputs/ServiceIncidentUrgencyRuleGetArgs.cs
+++ b/sdk/dotnet/Inputs/ServiceIncidentUrgencyRuleGetArgs.cs
@@ -12,18 +12,27 @@ namespace Pulumi.Pagerduty.Inputs
 
     public sealed class ServiceIncidentUrgencyRuleGetArgs : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// Incidents' urgency during support hours.
+        /// </summary>
         [Input("duringSupportHours")]
         public Input<Inputs.ServiceIncidentUrgencyRuleDuringSupportHoursGetArgs>? DuringSupportHours { get; set; }
 
+        /// <summary>
+        /// Incidents' urgency outside support hours.
+        /// </summary>
         [Input("outsideSupportHours")]
         public Input<Inputs.ServiceIncidentUrgencyRuleOutsideSupportHoursGetArgs>? OutsideSupportHours { get; set; }
 
         /// <summary>
-        /// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        /// The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).
         /// </summary>
         [Input("type", required: true)]
         public Input<string> Type { get; set; } = null!;
 
+        /// <summary>
+        /// The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.
+        /// </summary>
         [Input("urgency")]
         public Input<string>? Urgency { get; set; }
 

--- a/sdk/dotnet/Inputs/ServiceScheduledActionArgs.cs
+++ b/sdk/dotnet/Inputs/ServiceScheduledActionArgs.cs
@@ -14,17 +14,24 @@ namespace Pulumi.Pagerduty.Inputs
     {
         [Input("ats")]
         private InputList<Inputs.ServiceScheduledActionAtArgs>? _ats;
+
+        /// <summary>
+        /// A block representing when the scheduled action will occur.
+        /// </summary>
         public InputList<Inputs.ServiceScheduledActionAtArgs> Ats
         {
             get => _ats ?? (_ats = new InputList<Inputs.ServiceScheduledActionAtArgs>());
             set => _ats = value;
         }
 
+        /// <summary>
+        /// The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+        /// </summary>
         [Input("toUrgency")]
         public Input<string>? ToUrgency { get; set; }
 
         /// <summary>
-        /// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        /// The type of scheduled action. Currently, this must be set to `urgency_change`.
         /// </summary>
         [Input("type")]
         public Input<string>? Type { get; set; }

--- a/sdk/dotnet/Inputs/ServiceScheduledActionGetArgs.cs
+++ b/sdk/dotnet/Inputs/ServiceScheduledActionGetArgs.cs
@@ -14,17 +14,24 @@ namespace Pulumi.Pagerduty.Inputs
     {
         [Input("ats")]
         private InputList<Inputs.ServiceScheduledActionAtGetArgs>? _ats;
+
+        /// <summary>
+        /// A block representing when the scheduled action will occur.
+        /// </summary>
         public InputList<Inputs.ServiceScheduledActionAtGetArgs> Ats
         {
             get => _ats ?? (_ats = new InputList<Inputs.ServiceScheduledActionAtGetArgs>());
             set => _ats = value;
         }
 
+        /// <summary>
+        /// The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+        /// </summary>
         [Input("toUrgency")]
         public Input<string>? ToUrgency { get; set; }
 
         /// <summary>
-        /// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        /// The type of scheduled action. Currently, this must be set to `urgency_change`.
         /// </summary>
         [Input("type")]
         public Input<string>? Type { get; set; }

--- a/sdk/dotnet/Inputs/ServiceSupportHoursArgs.cs
+++ b/sdk/dotnet/Inputs/ServiceSupportHoursArgs.cs
@@ -14,23 +14,37 @@ namespace Pulumi.Pagerduty.Inputs
     {
         [Input("daysOfWeeks")]
         private InputList<int>? _daysOfWeeks;
+
+        /// <summary>
+        /// Array of days of week as integers. `1` to `7`, `1` being
+        /// Monday and `7` being Sunday.
+        /// </summary>
         public InputList<int> DaysOfWeeks
         {
             get => _daysOfWeeks ?? (_daysOfWeeks = new InputList<int>());
             set => _daysOfWeeks = value;
         }
 
+        /// <summary>
+        /// The support hours' ending time of day.
+        /// </summary>
         [Input("endTime")]
         public Input<string>? EndTime { get; set; }
 
+        /// <summary>
+        /// The support hours' starting time of day.
+        /// </summary>
         [Input("startTime")]
         public Input<string>? StartTime { get; set; }
 
+        /// <summary>
+        /// The time zone for the support hours.
+        /// </summary>
         [Input("timeZone")]
         public Input<string>? TimeZone { get; set; }
 
         /// <summary>
-        /// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        /// The type of support hours. Can be `fixed_time_per_day`.
         /// </summary>
         [Input("type")]
         public Input<string>? Type { get; set; }

--- a/sdk/dotnet/Inputs/ServiceSupportHoursGetArgs.cs
+++ b/sdk/dotnet/Inputs/ServiceSupportHoursGetArgs.cs
@@ -14,23 +14,37 @@ namespace Pulumi.Pagerduty.Inputs
     {
         [Input("daysOfWeeks")]
         private InputList<int>? _daysOfWeeks;
+
+        /// <summary>
+        /// Array of days of week as integers. `1` to `7`, `1` being
+        /// Monday and `7` being Sunday.
+        /// </summary>
         public InputList<int> DaysOfWeeks
         {
             get => _daysOfWeeks ?? (_daysOfWeeks = new InputList<int>());
             set => _daysOfWeeks = value;
         }
 
+        /// <summary>
+        /// The support hours' ending time of day.
+        /// </summary>
         [Input("endTime")]
         public Input<string>? EndTime { get; set; }
 
+        /// <summary>
+        /// The support hours' starting time of day.
+        /// </summary>
         [Input("startTime")]
         public Input<string>? StartTime { get; set; }
 
+        /// <summary>
+        /// The time zone for the support hours.
+        /// </summary>
         [Input("timeZone")]
         public Input<string>? TimeZone { get; set; }
 
         /// <summary>
-        /// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        /// The type of support hours. Can be `fixed_time_per_day`.
         /// </summary>
         [Input("type")]
         public Input<string>? Type { get; set; }

--- a/sdk/dotnet/Outputs/ServiceAutoPauseNotificationsParameters.cs
+++ b/sdk/dotnet/Outputs/ServiceAutoPauseNotificationsParameters.cs
@@ -19,11 +19,6 @@ namespace Pulumi.Pagerduty.Outputs
         public readonly bool? Enabled;
         /// <summary>
         /// Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-        /// 
-        /// 
-        /// You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
-        /// Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-        /// The block contains the following arguments:
         /// </summary>
         public readonly int? Timeout;
 

--- a/sdk/dotnet/Outputs/ServiceIncidentUrgencyRule.cs
+++ b/sdk/dotnet/Outputs/ServiceIncidentUrgencyRule.cs
@@ -13,12 +13,21 @@ namespace Pulumi.Pagerduty.Outputs
     [OutputType]
     public sealed class ServiceIncidentUrgencyRule
     {
+        /// <summary>
+        /// Incidents' urgency during support hours.
+        /// </summary>
         public readonly Outputs.ServiceIncidentUrgencyRuleDuringSupportHours? DuringSupportHours;
+        /// <summary>
+        /// Incidents' urgency outside support hours.
+        /// </summary>
         public readonly Outputs.ServiceIncidentUrgencyRuleOutsideSupportHours? OutsideSupportHours;
         /// <summary>
-        /// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        /// The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).
         /// </summary>
         public readonly string Type;
+        /// <summary>
+        /// The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.
+        /// </summary>
         public readonly string? Urgency;
 
         [OutputConstructor]

--- a/sdk/dotnet/Outputs/ServiceScheduledAction.cs
+++ b/sdk/dotnet/Outputs/ServiceScheduledAction.cs
@@ -13,10 +13,16 @@ namespace Pulumi.Pagerduty.Outputs
     [OutputType]
     public sealed class ServiceScheduledAction
     {
+        /// <summary>
+        /// A block representing when the scheduled action will occur.
+        /// </summary>
         public readonly ImmutableArray<Outputs.ServiceScheduledActionAt> Ats;
+        /// <summary>
+        /// The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+        /// </summary>
         public readonly string? ToUrgency;
         /// <summary>
-        /// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        /// The type of scheduled action. Currently, this must be set to `urgency_change`.
         /// </summary>
         public readonly string? Type;
 

--- a/sdk/dotnet/Outputs/ServiceSupportHours.cs
+++ b/sdk/dotnet/Outputs/ServiceSupportHours.cs
@@ -13,12 +13,25 @@ namespace Pulumi.Pagerduty.Outputs
     [OutputType]
     public sealed class ServiceSupportHours
     {
+        /// <summary>
+        /// Array of days of week as integers. `1` to `7`, `1` being
+        /// Monday and `7` being Sunday.
+        /// </summary>
         public readonly ImmutableArray<int> DaysOfWeeks;
+        /// <summary>
+        /// The support hours' ending time of day.
+        /// </summary>
         public readonly string? EndTime;
+        /// <summary>
+        /// The support hours' starting time of day.
+        /// </summary>
         public readonly string? StartTime;
+        /// <summary>
+        /// The time zone for the support hours.
+        /// </summary>
         public readonly string? TimeZone;
         /// <summary>
-        /// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        /// The type of support hours. Can be `fixed_time_per_day`.
         /// </summary>
         public readonly string? Type;
 

--- a/sdk/go/pagerduty/pulumiTypes.go
+++ b/sdk/go/pagerduty/pulumiTypes.go
@@ -13329,10 +13329,6 @@ type ServiceAutoPauseNotificationsParameters struct {
 	// Indicates whether alerts should be automatically suspended when identified as transient.  If not passed in, will default to 'false'.
 	Enabled *bool `pulumi:"enabled"`
 	// Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-	//
-	// You may specify one optional `incidentUrgencyRule` block configuring what urgencies to use.
-	// Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-	// The block contains the following arguments:
 	Timeout *int `pulumi:"timeout"`
 }
 
@@ -13351,10 +13347,6 @@ type ServiceAutoPauseNotificationsParametersArgs struct {
 	// Indicates whether alerts should be automatically suspended when identified as transient.  If not passed in, will default to 'false'.
 	Enabled pulumi.BoolPtrInput `pulumi:"enabled"`
 	// Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-	//
-	// You may specify one optional `incidentUrgencyRule` block configuring what urgencies to use.
-	// Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-	// The block contains the following arguments:
 	Timeout pulumi.IntPtrInput `pulumi:"timeout"`
 }
 
@@ -13441,10 +13433,6 @@ func (o ServiceAutoPauseNotificationsParametersOutput) Enabled() pulumi.BoolPtrO
 }
 
 // Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-//
-// You may specify one optional `incidentUrgencyRule` block configuring what urgencies to use.
-// Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-// The block contains the following arguments:
 func (o ServiceAutoPauseNotificationsParametersOutput) Timeout() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ServiceAutoPauseNotificationsParameters) *int { return v.Timeout }).(pulumi.IntPtrOutput)
 }
@@ -13484,10 +13472,6 @@ func (o ServiceAutoPauseNotificationsParametersPtrOutput) Enabled() pulumi.BoolP
 }
 
 // Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-//
-// You may specify one optional `incidentUrgencyRule` block configuring what urgencies to use.
-// Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-// The block contains the following arguments:
 func (o ServiceAutoPauseNotificationsParametersPtrOutput) Timeout() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *ServiceAutoPauseNotificationsParameters) *int {
 		if v == nil {
@@ -15828,10 +15812,13 @@ func (o ServiceEventRuleVariableParameterArrayOutput) Index(i pulumi.IntInput) S
 }
 
 type ServiceIncidentUrgencyRule struct {
-	DuringSupportHours  *ServiceIncidentUrgencyRuleDuringSupportHours  `pulumi:"duringSupportHours"`
+	// Incidents' urgency during support hours.
+	DuringSupportHours *ServiceIncidentUrgencyRuleDuringSupportHours `pulumi:"duringSupportHours"`
+	// Incidents' urgency outside support hours.
 	OutsideSupportHours *ServiceIncidentUrgencyRuleOutsideSupportHours `pulumi:"outsideSupportHours"`
-	// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
-	Type    string  `pulumi:"type"`
+	// The type of incident urgency: `constant` or `useSupportHours` (when depending on specific support hours; see `supportHours`).
+	Type string `pulumi:"type"`
+	// The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severityBased` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.
 	Urgency *string `pulumi:"urgency"`
 }
 
@@ -15847,10 +15834,13 @@ type ServiceIncidentUrgencyRuleInput interface {
 }
 
 type ServiceIncidentUrgencyRuleArgs struct {
-	DuringSupportHours  ServiceIncidentUrgencyRuleDuringSupportHoursPtrInput  `pulumi:"duringSupportHours"`
+	// Incidents' urgency during support hours.
+	DuringSupportHours ServiceIncidentUrgencyRuleDuringSupportHoursPtrInput `pulumi:"duringSupportHours"`
+	// Incidents' urgency outside support hours.
 	OutsideSupportHours ServiceIncidentUrgencyRuleOutsideSupportHoursPtrInput `pulumi:"outsideSupportHours"`
-	// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
-	Type    pulumi.StringInput    `pulumi:"type"`
+	// The type of incident urgency: `constant` or `useSupportHours` (when depending on specific support hours; see `supportHours`).
+	Type pulumi.StringInput `pulumi:"type"`
+	// The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severityBased` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.
 	Urgency pulumi.StringPtrInput `pulumi:"urgency"`
 }
 
@@ -15931,23 +15921,26 @@ func (o ServiceIncidentUrgencyRuleOutput) ToServiceIncidentUrgencyRulePtrOutputW
 	}).(ServiceIncidentUrgencyRulePtrOutput)
 }
 
+// Incidents' urgency during support hours.
 func (o ServiceIncidentUrgencyRuleOutput) DuringSupportHours() ServiceIncidentUrgencyRuleDuringSupportHoursPtrOutput {
 	return o.ApplyT(func(v ServiceIncidentUrgencyRule) *ServiceIncidentUrgencyRuleDuringSupportHours {
 		return v.DuringSupportHours
 	}).(ServiceIncidentUrgencyRuleDuringSupportHoursPtrOutput)
 }
 
+// Incidents' urgency outside support hours.
 func (o ServiceIncidentUrgencyRuleOutput) OutsideSupportHours() ServiceIncidentUrgencyRuleOutsideSupportHoursPtrOutput {
 	return o.ApplyT(func(v ServiceIncidentUrgencyRule) *ServiceIncidentUrgencyRuleOutsideSupportHours {
 		return v.OutsideSupportHours
 	}).(ServiceIncidentUrgencyRuleOutsideSupportHoursPtrOutput)
 }
 
-// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+// The type of incident urgency: `constant` or `useSupportHours` (when depending on specific support hours; see `supportHours`).
 func (o ServiceIncidentUrgencyRuleOutput) Type() pulumi.StringOutput {
 	return o.ApplyT(func(v ServiceIncidentUrgencyRule) string { return v.Type }).(pulumi.StringOutput)
 }
 
+// The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severityBased` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.
 func (o ServiceIncidentUrgencyRuleOutput) Urgency() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServiceIncidentUrgencyRule) *string { return v.Urgency }).(pulumi.StringPtrOutput)
 }
@@ -15976,6 +15969,7 @@ func (o ServiceIncidentUrgencyRulePtrOutput) Elem() ServiceIncidentUrgencyRuleOu
 	}).(ServiceIncidentUrgencyRuleOutput)
 }
 
+// Incidents' urgency during support hours.
 func (o ServiceIncidentUrgencyRulePtrOutput) DuringSupportHours() ServiceIncidentUrgencyRuleDuringSupportHoursPtrOutput {
 	return o.ApplyT(func(v *ServiceIncidentUrgencyRule) *ServiceIncidentUrgencyRuleDuringSupportHours {
 		if v == nil {
@@ -15985,6 +15979,7 @@ func (o ServiceIncidentUrgencyRulePtrOutput) DuringSupportHours() ServiceInciden
 	}).(ServiceIncidentUrgencyRuleDuringSupportHoursPtrOutput)
 }
 
+// Incidents' urgency outside support hours.
 func (o ServiceIncidentUrgencyRulePtrOutput) OutsideSupportHours() ServiceIncidentUrgencyRuleOutsideSupportHoursPtrOutput {
 	return o.ApplyT(func(v *ServiceIncidentUrgencyRule) *ServiceIncidentUrgencyRuleOutsideSupportHours {
 		if v == nil {
@@ -15994,7 +15989,7 @@ func (o ServiceIncidentUrgencyRulePtrOutput) OutsideSupportHours() ServiceIncide
 	}).(ServiceIncidentUrgencyRuleOutsideSupportHoursPtrOutput)
 }
 
-// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+// The type of incident urgency: `constant` or `useSupportHours` (when depending on specific support hours; see `supportHours`).
 func (o ServiceIncidentUrgencyRulePtrOutput) Type() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ServiceIncidentUrgencyRule) *string {
 		if v == nil {
@@ -16004,6 +15999,7 @@ func (o ServiceIncidentUrgencyRulePtrOutput) Type() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
+// The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severityBased` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.
 func (o ServiceIncidentUrgencyRulePtrOutput) Urgency() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ServiceIncidentUrgencyRule) *string {
 		if v == nil {
@@ -17031,9 +17027,11 @@ func (o ServiceIntegrationEmailParserValueExtractorArrayOutput) Index(i pulumi.I
 }
 
 type ServiceScheduledAction struct {
-	Ats       []ServiceScheduledActionAt `pulumi:"ats"`
-	ToUrgency *string                    `pulumi:"toUrgency"`
-	// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+	// A block representing when the scheduled action will occur.
+	Ats []ServiceScheduledActionAt `pulumi:"ats"`
+	// The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+	ToUrgency *string `pulumi:"toUrgency"`
+	// The type of scheduled action. Currently, this must be set to `urgencyChange`.
 	Type *string `pulumi:"type"`
 }
 
@@ -17049,9 +17047,11 @@ type ServiceScheduledActionInput interface {
 }
 
 type ServiceScheduledActionArgs struct {
-	Ats       ServiceScheduledActionAtArrayInput `pulumi:"ats"`
-	ToUrgency pulumi.StringPtrInput              `pulumi:"toUrgency"`
-	// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+	// A block representing when the scheduled action will occur.
+	Ats ServiceScheduledActionAtArrayInput `pulumi:"ats"`
+	// The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+	ToUrgency pulumi.StringPtrInput `pulumi:"toUrgency"`
+	// The type of scheduled action. Currently, this must be set to `urgencyChange`.
 	Type pulumi.StringPtrInput `pulumi:"type"`
 }
 
@@ -17106,15 +17106,17 @@ func (o ServiceScheduledActionOutput) ToServiceScheduledActionOutputWithContext(
 	return o
 }
 
+// A block representing when the scheduled action will occur.
 func (o ServiceScheduledActionOutput) Ats() ServiceScheduledActionAtArrayOutput {
 	return o.ApplyT(func(v ServiceScheduledAction) []ServiceScheduledActionAt { return v.Ats }).(ServiceScheduledActionAtArrayOutput)
 }
 
+// The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
 func (o ServiceScheduledActionOutput) ToUrgency() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServiceScheduledAction) *string { return v.ToUrgency }).(pulumi.StringPtrOutput)
 }
 
-// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+// The type of scheduled action. Currently, this must be set to `urgencyChange`.
 func (o ServiceScheduledActionOutput) Type() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServiceScheduledAction) *string { return v.Type }).(pulumi.StringPtrOutput)
 }
@@ -17444,11 +17446,16 @@ func (o ServiceScheduledActionAtArrayOutput) Index(i pulumi.IntInput) ServiceSch
 }
 
 type ServiceSupportHours struct {
-	DaysOfWeeks []int   `pulumi:"daysOfWeeks"`
-	EndTime     *string `pulumi:"endTime"`
-	StartTime   *string `pulumi:"startTime"`
-	TimeZone    *string `pulumi:"timeZone"`
-	// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+	// Array of days of week as integers. `1` to `7`, `1` being
+	// Monday and `7` being Sunday.
+	DaysOfWeeks []int `pulumi:"daysOfWeeks"`
+	// The support hours' ending time of day.
+	EndTime *string `pulumi:"endTime"`
+	// The support hours' starting time of day.
+	StartTime *string `pulumi:"startTime"`
+	// The time zone for the support hours.
+	TimeZone *string `pulumi:"timeZone"`
+	// The type of support hours. Can be `fixedTimePerDay`.
 	Type *string `pulumi:"type"`
 }
 
@@ -17464,11 +17471,16 @@ type ServiceSupportHoursInput interface {
 }
 
 type ServiceSupportHoursArgs struct {
-	DaysOfWeeks pulumi.IntArrayInput  `pulumi:"daysOfWeeks"`
-	EndTime     pulumi.StringPtrInput `pulumi:"endTime"`
-	StartTime   pulumi.StringPtrInput `pulumi:"startTime"`
-	TimeZone    pulumi.StringPtrInput `pulumi:"timeZone"`
-	// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+	// Array of days of week as integers. `1` to `7`, `1` being
+	// Monday and `7` being Sunday.
+	DaysOfWeeks pulumi.IntArrayInput `pulumi:"daysOfWeeks"`
+	// The support hours' ending time of day.
+	EndTime pulumi.StringPtrInput `pulumi:"endTime"`
+	// The support hours' starting time of day.
+	StartTime pulumi.StringPtrInput `pulumi:"startTime"`
+	// The time zone for the support hours.
+	TimeZone pulumi.StringPtrInput `pulumi:"timeZone"`
+	// The type of support hours. Can be `fixedTimePerDay`.
 	Type pulumi.StringPtrInput `pulumi:"type"`
 }
 
@@ -17549,23 +17561,28 @@ func (o ServiceSupportHoursOutput) ToServiceSupportHoursPtrOutputWithContext(ctx
 	}).(ServiceSupportHoursPtrOutput)
 }
 
+// Array of days of week as integers. `1` to `7`, `1` being
+// Monday and `7` being Sunday.
 func (o ServiceSupportHoursOutput) DaysOfWeeks() pulumi.IntArrayOutput {
 	return o.ApplyT(func(v ServiceSupportHours) []int { return v.DaysOfWeeks }).(pulumi.IntArrayOutput)
 }
 
+// The support hours' ending time of day.
 func (o ServiceSupportHoursOutput) EndTime() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServiceSupportHours) *string { return v.EndTime }).(pulumi.StringPtrOutput)
 }
 
+// The support hours' starting time of day.
 func (o ServiceSupportHoursOutput) StartTime() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServiceSupportHours) *string { return v.StartTime }).(pulumi.StringPtrOutput)
 }
 
+// The time zone for the support hours.
 func (o ServiceSupportHoursOutput) TimeZone() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServiceSupportHours) *string { return v.TimeZone }).(pulumi.StringPtrOutput)
 }
 
-// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+// The type of support hours. Can be `fixedTimePerDay`.
 func (o ServiceSupportHoursOutput) Type() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServiceSupportHours) *string { return v.Type }).(pulumi.StringPtrOutput)
 }
@@ -17594,6 +17611,8 @@ func (o ServiceSupportHoursPtrOutput) Elem() ServiceSupportHoursOutput {
 	}).(ServiceSupportHoursOutput)
 }
 
+// Array of days of week as integers. `1` to `7`, `1` being
+// Monday and `7` being Sunday.
 func (o ServiceSupportHoursPtrOutput) DaysOfWeeks() pulumi.IntArrayOutput {
 	return o.ApplyT(func(v *ServiceSupportHours) []int {
 		if v == nil {
@@ -17603,6 +17622,7 @@ func (o ServiceSupportHoursPtrOutput) DaysOfWeeks() pulumi.IntArrayOutput {
 	}).(pulumi.IntArrayOutput)
 }
 
+// The support hours' ending time of day.
 func (o ServiceSupportHoursPtrOutput) EndTime() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ServiceSupportHours) *string {
 		if v == nil {
@@ -17612,6 +17632,7 @@ func (o ServiceSupportHoursPtrOutput) EndTime() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
+// The support hours' starting time of day.
 func (o ServiceSupportHoursPtrOutput) StartTime() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ServiceSupportHours) *string {
 		if v == nil {
@@ -17621,6 +17642,7 @@ func (o ServiceSupportHoursPtrOutput) StartTime() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
+// The time zone for the support hours.
 func (o ServiceSupportHoursPtrOutput) TimeZone() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ServiceSupportHours) *string {
 		if v == nil {
@@ -17630,7 +17652,7 @@ func (o ServiceSupportHoursPtrOutput) TimeZone() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+// The type of support hours. Can be `fixedTimePerDay`.
 func (o ServiceSupportHoursPtrOutput) Type() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ServiceSupportHours) *string {
 		if v == nil {

--- a/sdk/java/src/main/java/com/pulumi/pagerduty/inputs/ServiceAutoPauseNotificationsParametersArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pagerduty/inputs/ServiceAutoPauseNotificationsParametersArgs.java
@@ -34,20 +34,12 @@ public final class ServiceAutoPauseNotificationsParametersArgs extends com.pulum
     /**
      * Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
      * 
-     * You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
-     * Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-     * The block contains the following arguments:
-     * 
      */
     @Import(name="timeout")
     private @Nullable Output<Integer> timeout;
 
     /**
      * @return Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-     * 
-     * You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
-     * Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-     * The block contains the following arguments:
      * 
      */
     public Optional<Output<Integer>> timeout() {
@@ -103,10 +95,6 @@ public final class ServiceAutoPauseNotificationsParametersArgs extends com.pulum
         /**
          * @param timeout Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
          * 
-         * You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
-         * Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-         * The block contains the following arguments:
-         * 
          * @return builder
          * 
          */
@@ -117,10 +105,6 @@ public final class ServiceAutoPauseNotificationsParametersArgs extends com.pulum
 
         /**
          * @param timeout Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-         * 
-         * You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
-         * Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-         * The block contains the following arguments:
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/pagerduty/inputs/ServiceIncidentUrgencyRuleArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pagerduty/inputs/ServiceIncidentUrgencyRuleArgs.java
@@ -18,38 +18,62 @@ public final class ServiceIncidentUrgencyRuleArgs extends com.pulumi.resources.R
 
     public static final ServiceIncidentUrgencyRuleArgs Empty = new ServiceIncidentUrgencyRuleArgs();
 
+    /**
+     * Incidents&#39; urgency during support hours.
+     * 
+     */
     @Import(name="duringSupportHours")
     private @Nullable Output<ServiceIncidentUrgencyRuleDuringSupportHoursArgs> duringSupportHours;
 
+    /**
+     * @return Incidents&#39; urgency during support hours.
+     * 
+     */
     public Optional<Output<ServiceIncidentUrgencyRuleDuringSupportHoursArgs>> duringSupportHours() {
         return Optional.ofNullable(this.duringSupportHours);
     }
 
+    /**
+     * Incidents&#39; urgency outside support hours.
+     * 
+     */
     @Import(name="outsideSupportHours")
     private @Nullable Output<ServiceIncidentUrgencyRuleOutsideSupportHoursArgs> outsideSupportHours;
 
+    /**
+     * @return Incidents&#39; urgency outside support hours.
+     * 
+     */
     public Optional<Output<ServiceIncidentUrgencyRuleOutsideSupportHoursArgs>> outsideSupportHours() {
         return Optional.ofNullable(this.outsideSupportHours);
     }
 
     /**
-     * The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).
      * 
      */
     @Import(name="type", required=true)
     private Output<String> type;
 
     /**
-     * @return The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * @return The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).
      * 
      */
     public Output<String> type() {
         return this.type;
     }
 
+    /**
+     * The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set&#39;s the urgency of the incident based on the severity set by the triggering monitoring tool.
+     * 
+     */
     @Import(name="urgency")
     private @Nullable Output<String> urgency;
 
+    /**
+     * @return The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set&#39;s the urgency of the incident based on the severity set by the triggering monitoring tool.
+     * 
+     */
     public Optional<Output<String>> urgency() {
         return Optional.ofNullable(this.urgency);
     }
@@ -81,26 +105,50 @@ public final class ServiceIncidentUrgencyRuleArgs extends com.pulumi.resources.R
             $ = new ServiceIncidentUrgencyRuleArgs(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @param duringSupportHours Incidents&#39; urgency during support hours.
+         * 
+         * @return builder
+         * 
+         */
         public Builder duringSupportHours(@Nullable Output<ServiceIncidentUrgencyRuleDuringSupportHoursArgs> duringSupportHours) {
             $.duringSupportHours = duringSupportHours;
             return this;
         }
 
+        /**
+         * @param duringSupportHours Incidents&#39; urgency during support hours.
+         * 
+         * @return builder
+         * 
+         */
         public Builder duringSupportHours(ServiceIncidentUrgencyRuleDuringSupportHoursArgs duringSupportHours) {
             return duringSupportHours(Output.of(duringSupportHours));
         }
 
+        /**
+         * @param outsideSupportHours Incidents&#39; urgency outside support hours.
+         * 
+         * @return builder
+         * 
+         */
         public Builder outsideSupportHours(@Nullable Output<ServiceIncidentUrgencyRuleOutsideSupportHoursArgs> outsideSupportHours) {
             $.outsideSupportHours = outsideSupportHours;
             return this;
         }
 
+        /**
+         * @param outsideSupportHours Incidents&#39; urgency outside support hours.
+         * 
+         * @return builder
+         * 
+         */
         public Builder outsideSupportHours(ServiceIncidentUrgencyRuleOutsideSupportHoursArgs outsideSupportHours) {
             return outsideSupportHours(Output.of(outsideSupportHours));
         }
 
         /**
-         * @param type The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+         * @param type The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).
          * 
          * @return builder
          * 
@@ -111,7 +159,7 @@ public final class ServiceIncidentUrgencyRuleArgs extends com.pulumi.resources.R
         }
 
         /**
-         * @param type The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+         * @param type The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).
          * 
          * @return builder
          * 
@@ -120,11 +168,23 @@ public final class ServiceIncidentUrgencyRuleArgs extends com.pulumi.resources.R
             return type(Output.of(type));
         }
 
+        /**
+         * @param urgency The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set&#39;s the urgency of the incident based on the severity set by the triggering monitoring tool.
+         * 
+         * @return builder
+         * 
+         */
         public Builder urgency(@Nullable Output<String> urgency) {
             $.urgency = urgency;
             return this;
         }
 
+        /**
+         * @param urgency The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set&#39;s the urgency of the incident based on the severity set by the triggering monitoring tool.
+         * 
+         * @return builder
+         * 
+         */
         public Builder urgency(String urgency) {
             return urgency(Output.of(urgency));
         }

--- a/sdk/java/src/main/java/com/pulumi/pagerduty/inputs/ServiceScheduledActionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pagerduty/inputs/ServiceScheduledActionArgs.java
@@ -17,29 +17,45 @@ public final class ServiceScheduledActionArgs extends com.pulumi.resources.Resou
 
     public static final ServiceScheduledActionArgs Empty = new ServiceScheduledActionArgs();
 
+    /**
+     * A block representing when the scheduled action will occur.
+     * 
+     */
     @Import(name="ats")
     private @Nullable Output<List<ServiceScheduledActionAtArgs>> ats;
 
+    /**
+     * @return A block representing when the scheduled action will occur.
+     * 
+     */
     public Optional<Output<List<ServiceScheduledActionAtArgs>>> ats() {
         return Optional.ofNullable(this.ats);
     }
 
+    /**
+     * The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+     * 
+     */
     @Import(name="toUrgency")
     private @Nullable Output<String> toUrgency;
 
+    /**
+     * @return The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+     * 
+     */
     public Optional<Output<String>> toUrgency() {
         return Optional.ofNullable(this.toUrgency);
     }
 
     /**
-     * The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * The type of scheduled action. Currently, this must be set to `urgency_change`.
      * 
      */
     @Import(name="type")
     private @Nullable Output<String> type;
 
     /**
-     * @return The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * @return The type of scheduled action. Currently, this must be set to `urgency_change`.
      * 
      */
     public Optional<Output<String>> type() {
@@ -72,30 +88,60 @@ public final class ServiceScheduledActionArgs extends com.pulumi.resources.Resou
             $ = new ServiceScheduledActionArgs(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @param ats A block representing when the scheduled action will occur.
+         * 
+         * @return builder
+         * 
+         */
         public Builder ats(@Nullable Output<List<ServiceScheduledActionAtArgs>> ats) {
             $.ats = ats;
             return this;
         }
 
+        /**
+         * @param ats A block representing when the scheduled action will occur.
+         * 
+         * @return builder
+         * 
+         */
         public Builder ats(List<ServiceScheduledActionAtArgs> ats) {
             return ats(Output.of(ats));
         }
 
+        /**
+         * @param ats A block representing when the scheduled action will occur.
+         * 
+         * @return builder
+         * 
+         */
         public Builder ats(ServiceScheduledActionAtArgs... ats) {
             return ats(List.of(ats));
         }
 
+        /**
+         * @param toUrgency The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+         * 
+         * @return builder
+         * 
+         */
         public Builder toUrgency(@Nullable Output<String> toUrgency) {
             $.toUrgency = toUrgency;
             return this;
         }
 
+        /**
+         * @param toUrgency The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+         * 
+         * @return builder
+         * 
+         */
         public Builder toUrgency(String toUrgency) {
             return toUrgency(Output.of(toUrgency));
         }
 
         /**
-         * @param type The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+         * @param type The type of scheduled action. Currently, this must be set to `urgency_change`.
          * 
          * @return builder
          * 
@@ -106,7 +152,7 @@ public final class ServiceScheduledActionArgs extends com.pulumi.resources.Resou
         }
 
         /**
-         * @param type The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+         * @param type The type of scheduled action. Currently, this must be set to `urgency_change`.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/pagerduty/inputs/ServiceSupportHoursArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pagerduty/inputs/ServiceSupportHoursArgs.java
@@ -17,43 +17,77 @@ public final class ServiceSupportHoursArgs extends com.pulumi.resources.Resource
 
     public static final ServiceSupportHoursArgs Empty = new ServiceSupportHoursArgs();
 
+    /**
+     * Array of days of week as integers. `1` to `7`, `1` being
+     * Monday and `7` being Sunday.
+     * 
+     */
     @Import(name="daysOfWeeks")
     private @Nullable Output<List<Integer>> daysOfWeeks;
 
+    /**
+     * @return Array of days of week as integers. `1` to `7`, `1` being
+     * Monday and `7` being Sunday.
+     * 
+     */
     public Optional<Output<List<Integer>>> daysOfWeeks() {
         return Optional.ofNullable(this.daysOfWeeks);
     }
 
+    /**
+     * The support hours&#39; ending time of day.
+     * 
+     */
     @Import(name="endTime")
     private @Nullable Output<String> endTime;
 
+    /**
+     * @return The support hours&#39; ending time of day.
+     * 
+     */
     public Optional<Output<String>> endTime() {
         return Optional.ofNullable(this.endTime);
     }
 
+    /**
+     * The support hours&#39; starting time of day.
+     * 
+     */
     @Import(name="startTime")
     private @Nullable Output<String> startTime;
 
+    /**
+     * @return The support hours&#39; starting time of day.
+     * 
+     */
     public Optional<Output<String>> startTime() {
         return Optional.ofNullable(this.startTime);
     }
 
+    /**
+     * The time zone for the support hours.
+     * 
+     */
     @Import(name="timeZone")
     private @Nullable Output<String> timeZone;
 
+    /**
+     * @return The time zone for the support hours.
+     * 
+     */
     public Optional<Output<String>> timeZone() {
         return Optional.ofNullable(this.timeZone);
     }
 
     /**
-     * The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * The type of support hours. Can be `fixed_time_per_day`.
      * 
      */
     @Import(name="type")
     private @Nullable Output<String> type;
 
     /**
-     * @return The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * @return The type of support hours. Can be `fixed_time_per_day`.
      * 
      */
     public Optional<Output<String>> type() {
@@ -88,48 +122,105 @@ public final class ServiceSupportHoursArgs extends com.pulumi.resources.Resource
             $ = new ServiceSupportHoursArgs(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @param daysOfWeeks Array of days of week as integers. `1` to `7`, `1` being
+         * Monday and `7` being Sunday.
+         * 
+         * @return builder
+         * 
+         */
         public Builder daysOfWeeks(@Nullable Output<List<Integer>> daysOfWeeks) {
             $.daysOfWeeks = daysOfWeeks;
             return this;
         }
 
+        /**
+         * @param daysOfWeeks Array of days of week as integers. `1` to `7`, `1` being
+         * Monday and `7` being Sunday.
+         * 
+         * @return builder
+         * 
+         */
         public Builder daysOfWeeks(List<Integer> daysOfWeeks) {
             return daysOfWeeks(Output.of(daysOfWeeks));
         }
 
+        /**
+         * @param daysOfWeeks Array of days of week as integers. `1` to `7`, `1` being
+         * Monday and `7` being Sunday.
+         * 
+         * @return builder
+         * 
+         */
         public Builder daysOfWeeks(Integer... daysOfWeeks) {
             return daysOfWeeks(List.of(daysOfWeeks));
         }
 
+        /**
+         * @param endTime The support hours&#39; ending time of day.
+         * 
+         * @return builder
+         * 
+         */
         public Builder endTime(@Nullable Output<String> endTime) {
             $.endTime = endTime;
             return this;
         }
 
+        /**
+         * @param endTime The support hours&#39; ending time of day.
+         * 
+         * @return builder
+         * 
+         */
         public Builder endTime(String endTime) {
             return endTime(Output.of(endTime));
         }
 
+        /**
+         * @param startTime The support hours&#39; starting time of day.
+         * 
+         * @return builder
+         * 
+         */
         public Builder startTime(@Nullable Output<String> startTime) {
             $.startTime = startTime;
             return this;
         }
 
+        /**
+         * @param startTime The support hours&#39; starting time of day.
+         * 
+         * @return builder
+         * 
+         */
         public Builder startTime(String startTime) {
             return startTime(Output.of(startTime));
         }
 
+        /**
+         * @param timeZone The time zone for the support hours.
+         * 
+         * @return builder
+         * 
+         */
         public Builder timeZone(@Nullable Output<String> timeZone) {
             $.timeZone = timeZone;
             return this;
         }
 
+        /**
+         * @param timeZone The time zone for the support hours.
+         * 
+         * @return builder
+         * 
+         */
         public Builder timeZone(String timeZone) {
             return timeZone(Output.of(timeZone));
         }
 
         /**
-         * @param type The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+         * @param type The type of support hours. Can be `fixed_time_per_day`.
          * 
          * @return builder
          * 
@@ -140,7 +231,7 @@ public final class ServiceSupportHoursArgs extends com.pulumi.resources.Resource
         }
 
         /**
-         * @param type The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+         * @param type The type of support hours. Can be `fixed_time_per_day`.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/pagerduty/outputs/ServiceAutoPauseNotificationsParameters.java
+++ b/sdk/java/src/main/java/com/pulumi/pagerduty/outputs/ServiceAutoPauseNotificationsParameters.java
@@ -20,10 +20,6 @@ public final class ServiceAutoPauseNotificationsParameters {
     /**
      * @return Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
      * 
-     * You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
-     * Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-     * The block contains the following arguments:
-     * 
      */
     private @Nullable Integer timeout;
 
@@ -37,10 +33,6 @@ public final class ServiceAutoPauseNotificationsParameters {
     }
     /**
      * @return Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-     * 
-     * You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
-     * Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-     * The block contains the following arguments:
      * 
      */
     public Optional<Integer> timeout() {

--- a/sdk/java/src/main/java/com/pulumi/pagerduty/outputs/ServiceIncidentUrgencyRule.java
+++ b/sdk/java/src/main/java/com/pulumi/pagerduty/outputs/ServiceIncidentUrgencyRule.java
@@ -14,29 +14,53 @@ import javax.annotation.Nullable;
 
 @CustomType
 public final class ServiceIncidentUrgencyRule {
+    /**
+     * @return Incidents&#39; urgency during support hours.
+     * 
+     */
     private @Nullable ServiceIncidentUrgencyRuleDuringSupportHours duringSupportHours;
+    /**
+     * @return Incidents&#39; urgency outside support hours.
+     * 
+     */
     private @Nullable ServiceIncidentUrgencyRuleOutsideSupportHours outsideSupportHours;
     /**
-     * @return The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * @return The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).
      * 
      */
     private String type;
+    /**
+     * @return The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set&#39;s the urgency of the incident based on the severity set by the triggering monitoring tool.
+     * 
+     */
     private @Nullable String urgency;
 
     private ServiceIncidentUrgencyRule() {}
+    /**
+     * @return Incidents&#39; urgency during support hours.
+     * 
+     */
     public Optional<ServiceIncidentUrgencyRuleDuringSupportHours> duringSupportHours() {
         return Optional.ofNullable(this.duringSupportHours);
     }
+    /**
+     * @return Incidents&#39; urgency outside support hours.
+     * 
+     */
     public Optional<ServiceIncidentUrgencyRuleOutsideSupportHours> outsideSupportHours() {
         return Optional.ofNullable(this.outsideSupportHours);
     }
     /**
-     * @return The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * @return The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).
      * 
      */
     public String type() {
         return this.type;
     }
+    /**
+     * @return The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set&#39;s the urgency of the incident based on the severity set by the triggering monitoring tool.
+     * 
+     */
     public Optional<String> urgency() {
         return Optional.ofNullable(this.urgency);
     }

--- a/sdk/java/src/main/java/com/pulumi/pagerduty/outputs/ServiceScheduledAction.java
+++ b/sdk/java/src/main/java/com/pulumi/pagerduty/outputs/ServiceScheduledAction.java
@@ -13,23 +13,39 @@ import javax.annotation.Nullable;
 
 @CustomType
 public final class ServiceScheduledAction {
+    /**
+     * @return A block representing when the scheduled action will occur.
+     * 
+     */
     private @Nullable List<ServiceScheduledActionAt> ats;
+    /**
+     * @return The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+     * 
+     */
     private @Nullable String toUrgency;
     /**
-     * @return The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * @return The type of scheduled action. Currently, this must be set to `urgency_change`.
      * 
      */
     private @Nullable String type;
 
     private ServiceScheduledAction() {}
+    /**
+     * @return A block representing when the scheduled action will occur.
+     * 
+     */
     public List<ServiceScheduledActionAt> ats() {
         return this.ats == null ? List.of() : this.ats;
     }
+    /**
+     * @return The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+     * 
+     */
     public Optional<String> toUrgency() {
         return Optional.ofNullable(this.toUrgency);
     }
     /**
-     * @return The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * @return The type of scheduled action. Currently, this must be set to `urgency_change`.
      * 
      */
     public Optional<String> type() {

--- a/sdk/java/src/main/java/com/pulumi/pagerduty/outputs/ServiceSupportHours.java
+++ b/sdk/java/src/main/java/com/pulumi/pagerduty/outputs/ServiceSupportHours.java
@@ -13,31 +13,65 @@ import javax.annotation.Nullable;
 
 @CustomType
 public final class ServiceSupportHours {
+    /**
+     * @return Array of days of week as integers. `1` to `7`, `1` being
+     * Monday and `7` being Sunday.
+     * 
+     */
     private @Nullable List<Integer> daysOfWeeks;
+    /**
+     * @return The support hours&#39; ending time of day.
+     * 
+     */
     private @Nullable String endTime;
+    /**
+     * @return The support hours&#39; starting time of day.
+     * 
+     */
     private @Nullable String startTime;
+    /**
+     * @return The time zone for the support hours.
+     * 
+     */
     private @Nullable String timeZone;
     /**
-     * @return The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * @return The type of support hours. Can be `fixed_time_per_day`.
      * 
      */
     private @Nullable String type;
 
     private ServiceSupportHours() {}
+    /**
+     * @return Array of days of week as integers. `1` to `7`, `1` being
+     * Monday and `7` being Sunday.
+     * 
+     */
     public List<Integer> daysOfWeeks() {
         return this.daysOfWeeks == null ? List.of() : this.daysOfWeeks;
     }
+    /**
+     * @return The support hours&#39; ending time of day.
+     * 
+     */
     public Optional<String> endTime() {
         return Optional.ofNullable(this.endTime);
     }
+    /**
+     * @return The support hours&#39; starting time of day.
+     * 
+     */
     public Optional<String> startTime() {
         return Optional.ofNullable(this.startTime);
     }
+    /**
+     * @return The time zone for the support hours.
+     * 
+     */
     public Optional<String> timeZone() {
         return Optional.ofNullable(this.timeZone);
     }
     /**
-     * @return The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * @return The type of support hours. Can be `fixed_time_per_day`.
      * 
      */
     public Optional<String> type() {

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -1638,11 +1638,6 @@ export interface ServiceAutoPauseNotificationsParameters {
     enabled?: pulumi.Input<boolean>;
     /**
      * Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-     *
-     *
-     * You may specify one optional `incidentUrgencyRule` block configuring what urgencies to use.
-     * Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-     * The block contains the following arguments:
      */
     timeout?: pulumi.Input<number>;
 }
@@ -1857,12 +1852,21 @@ export interface ServiceEventRuleVariableParameter {
 }
 
 export interface ServiceIncidentUrgencyRule {
+    /**
+     * Incidents' urgency during support hours.
+     */
     duringSupportHours?: pulumi.Input<inputs.ServiceIncidentUrgencyRuleDuringSupportHours>;
+    /**
+     * Incidents' urgency outside support hours.
+     */
     outsideSupportHours?: pulumi.Input<inputs.ServiceIncidentUrgencyRuleOutsideSupportHours>;
     /**
-     * The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * The type of incident urgency: `constant` or `useSupportHours` (when depending on specific support hours; see `supportHours`).
      */
     type: pulumi.Input<string>;
+    /**
+     * The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severityBased` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.
+     */
     urgency?: pulumi.Input<string>;
 }
 
@@ -1989,10 +1993,16 @@ export interface ServiceIntegrationEmailParserValueExtractor {
 }
 
 export interface ServiceScheduledAction {
+    /**
+     * A block representing when the scheduled action will occur.
+     */
     ats?: pulumi.Input<pulumi.Input<inputs.ServiceScheduledActionAt>[]>;
+    /**
+     * The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+     */
     toUrgency?: pulumi.Input<string>;
     /**
-     * The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * The type of scheduled action. Currently, this must be set to `urgencyChange`.
      */
     type?: pulumi.Input<string>;
 }
@@ -2058,12 +2068,25 @@ export interface ServiceScheduledActionAt {
 }
 
 export interface ServiceSupportHours {
+    /**
+     * Array of days of week as integers. `1` to `7`, `1` being
+     * Monday and `7` being Sunday.
+     */
     daysOfWeeks?: pulumi.Input<pulumi.Input<number>[]>;
+    /**
+     * The support hours' ending time of day.
+     */
     endTime?: pulumi.Input<string>;
+    /**
+     * The support hours' starting time of day.
+     */
     startTime?: pulumi.Input<string>;
+    /**
+     * The time zone for the support hours.
+     */
     timeZone?: pulumi.Input<string>;
     /**
-     * The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * The type of support hours. Can be `fixedTimePerDay`.
      */
     type?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -1909,11 +1909,6 @@ export interface ServiceAutoPauseNotificationsParameters {
     enabled: boolean;
     /**
      * Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-     *
-     *
-     * You may specify one optional `incidentUrgencyRule` block configuring what urgencies to use.
-     * Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-     * The block contains the following arguments:
      */
     timeout: number;
 }
@@ -2128,12 +2123,21 @@ export interface ServiceEventRuleVariableParameter {
 }
 
 export interface ServiceIncidentUrgencyRule {
+    /**
+     * Incidents' urgency during support hours.
+     */
     duringSupportHours?: outputs.ServiceIncidentUrgencyRuleDuringSupportHours;
+    /**
+     * Incidents' urgency outside support hours.
+     */
     outsideSupportHours?: outputs.ServiceIncidentUrgencyRuleOutsideSupportHours;
     /**
-     * The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * The type of incident urgency: `constant` or `useSupportHours` (when depending on specific support hours; see `supportHours`).
      */
     type: string;
+    /**
+     * The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severityBased` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.
+     */
     urgency?: string;
 }
 
@@ -2260,10 +2264,16 @@ export interface ServiceIntegrationEmailParserValueExtractor {
 }
 
 export interface ServiceScheduledAction {
+    /**
+     * A block representing when the scheduled action will occur.
+     */
     ats?: outputs.ServiceScheduledActionAt[];
+    /**
+     * The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+     */
     toUrgency?: string;
     /**
-     * The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * The type of scheduled action. Currently, this must be set to `urgencyChange`.
      */
     type?: string;
 }
@@ -2329,12 +2339,25 @@ export interface ServiceScheduledActionAt {
 }
 
 export interface ServiceSupportHours {
+    /**
+     * Array of days of week as integers. `1` to `7`, `1` being
+     * Monday and `7` being Sunday.
+     */
     daysOfWeeks?: number[];
+    /**
+     * The support hours' ending time of day.
+     */
     endTime?: string;
+    /**
+     * The support hours' starting time of day.
+     */
     startTime?: string;
+    /**
+     * The time zone for the support hours.
+     */
     timeZone?: string;
     /**
-     * The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+     * The type of support hours. Can be `fixedTimePerDay`.
      */
     type?: string;
 }

--- a/sdk/python/pulumi_pagerduty/_inputs.py
+++ b/sdk/python/pulumi_pagerduty/_inputs.py
@@ -5777,11 +5777,6 @@ class ServiceAutoPauseNotificationsParametersArgs:
         """
         :param pulumi.Input[bool] enabled: Indicates whether alerts should be automatically suspended when identified as transient.  If not passed in, will default to 'false'.
         :param pulumi.Input[int] timeout: Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-               
-               
-               You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
-               Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-               The block contains the following arguments:
         """
         if enabled is not None:
             pulumi.set(__self__, "enabled", enabled)
@@ -5805,11 +5800,6 @@ class ServiceAutoPauseNotificationsParametersArgs:
     def timeout(self) -> Optional[pulumi.Input[int]]:
         """
         Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-
-
-        You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
-        Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-        The block contains the following arguments:
         """
         return pulumi.get(self, "timeout")
 
@@ -6633,7 +6623,10 @@ class ServiceIncidentUrgencyRuleArgs:
                  outside_support_hours: Optional[pulumi.Input['ServiceIncidentUrgencyRuleOutsideSupportHoursArgs']] = None,
                  urgency: Optional[pulumi.Input[str]] = None):
         """
-        :param pulumi.Input[str] type: The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        :param pulumi.Input[str] type: The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).
+        :param pulumi.Input['ServiceIncidentUrgencyRuleDuringSupportHoursArgs'] during_support_hours: Incidents' urgency during support hours.
+        :param pulumi.Input['ServiceIncidentUrgencyRuleOutsideSupportHoursArgs'] outside_support_hours: Incidents' urgency outside support hours.
+        :param pulumi.Input[str] urgency: The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.
         """
         pulumi.set(__self__, "type", type)
         if during_support_hours is not None:
@@ -6647,7 +6640,7 @@ class ServiceIncidentUrgencyRuleArgs:
     @pulumi.getter
     def type(self) -> pulumi.Input[str]:
         """
-        The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).
         """
         return pulumi.get(self, "type")
 
@@ -6658,6 +6651,9 @@ class ServiceIncidentUrgencyRuleArgs:
     @property
     @pulumi.getter(name="duringSupportHours")
     def during_support_hours(self) -> Optional[pulumi.Input['ServiceIncidentUrgencyRuleDuringSupportHoursArgs']]:
+        """
+        Incidents' urgency during support hours.
+        """
         return pulumi.get(self, "during_support_hours")
 
     @during_support_hours.setter
@@ -6667,6 +6663,9 @@ class ServiceIncidentUrgencyRuleArgs:
     @property
     @pulumi.getter(name="outsideSupportHours")
     def outside_support_hours(self) -> Optional[pulumi.Input['ServiceIncidentUrgencyRuleOutsideSupportHoursArgs']]:
+        """
+        Incidents' urgency outside support hours.
+        """
         return pulumi.get(self, "outside_support_hours")
 
     @outside_support_hours.setter
@@ -6676,6 +6675,9 @@ class ServiceIncidentUrgencyRuleArgs:
     @property
     @pulumi.getter
     def urgency(self) -> Optional[pulumi.Input[str]]:
+        """
+        The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.
+        """
         return pulumi.get(self, "urgency")
 
     @urgency.setter
@@ -7188,7 +7190,9 @@ class ServiceScheduledActionArgs:
                  to_urgency: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input[str]] = None):
         """
-        :param pulumi.Input[str] type: The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        :param pulumi.Input[Sequence[pulumi.Input['ServiceScheduledActionAtArgs']]] ats: A block representing when the scheduled action will occur.
+        :param pulumi.Input[str] to_urgency: The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+        :param pulumi.Input[str] type: The type of scheduled action. Currently, this must be set to `urgency_change`.
         """
         if ats is not None:
             pulumi.set(__self__, "ats", ats)
@@ -7200,6 +7204,9 @@ class ServiceScheduledActionArgs:
     @property
     @pulumi.getter
     def ats(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['ServiceScheduledActionAtArgs']]]]:
+        """
+        A block representing when the scheduled action will occur.
+        """
         return pulumi.get(self, "ats")
 
     @ats.setter
@@ -7209,6 +7216,9 @@ class ServiceScheduledActionArgs:
     @property
     @pulumi.getter(name="toUrgency")
     def to_urgency(self) -> Optional[pulumi.Input[str]]:
+        """
+        The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+        """
         return pulumi.get(self, "to_urgency")
 
     @to_urgency.setter
@@ -7219,7 +7229,7 @@ class ServiceScheduledActionArgs:
     @pulumi.getter
     def type(self) -> Optional[pulumi.Input[str]]:
         """
-        The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        The type of scheduled action. Currently, this must be set to `urgency_change`.
         """
         return pulumi.get(self, "type")
 
@@ -7372,7 +7382,12 @@ class ServiceSupportHoursArgs:
                  time_zone: Optional[pulumi.Input[str]] = None,
                  type: Optional[pulumi.Input[str]] = None):
         """
-        :param pulumi.Input[str] type: The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        :param pulumi.Input[Sequence[pulumi.Input[int]]] days_of_weeks: Array of days of week as integers. `1` to `7`, `1` being
+               Monday and `7` being Sunday.
+        :param pulumi.Input[str] end_time: The support hours' ending time of day.
+        :param pulumi.Input[str] start_time: The support hours' starting time of day.
+        :param pulumi.Input[str] time_zone: The time zone for the support hours.
+        :param pulumi.Input[str] type: The type of support hours. Can be `fixed_time_per_day`.
         """
         if days_of_weeks is not None:
             pulumi.set(__self__, "days_of_weeks", days_of_weeks)
@@ -7388,6 +7403,10 @@ class ServiceSupportHoursArgs:
     @property
     @pulumi.getter(name="daysOfWeeks")
     def days_of_weeks(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[int]]]]:
+        """
+        Array of days of week as integers. `1` to `7`, `1` being
+        Monday and `7` being Sunday.
+        """
         return pulumi.get(self, "days_of_weeks")
 
     @days_of_weeks.setter
@@ -7397,6 +7416,9 @@ class ServiceSupportHoursArgs:
     @property
     @pulumi.getter(name="endTime")
     def end_time(self) -> Optional[pulumi.Input[str]]:
+        """
+        The support hours' ending time of day.
+        """
         return pulumi.get(self, "end_time")
 
     @end_time.setter
@@ -7406,6 +7428,9 @@ class ServiceSupportHoursArgs:
     @property
     @pulumi.getter(name="startTime")
     def start_time(self) -> Optional[pulumi.Input[str]]:
+        """
+        The support hours' starting time of day.
+        """
         return pulumi.get(self, "start_time")
 
     @start_time.setter
@@ -7415,6 +7440,9 @@ class ServiceSupportHoursArgs:
     @property
     @pulumi.getter(name="timeZone")
     def time_zone(self) -> Optional[pulumi.Input[str]]:
+        """
+        The time zone for the support hours.
+        """
         return pulumi.get(self, "time_zone")
 
     @time_zone.setter
@@ -7425,7 +7453,7 @@ class ServiceSupportHoursArgs:
     @pulumi.getter
     def type(self) -> Optional[pulumi.Input[str]]:
         """
-        The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        The type of support hours. Can be `fixed_time_per_day`.
         """
         return pulumi.get(self, "type")
 

--- a/sdk/python/pulumi_pagerduty/outputs.py
+++ b/sdk/python/pulumi_pagerduty/outputs.py
@@ -5090,11 +5090,6 @@ class ServiceAutoPauseNotificationsParameters(dict):
         """
         :param bool enabled: Indicates whether alerts should be automatically suspended when identified as transient.  If not passed in, will default to 'false'.
         :param int timeout: Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-               
-               
-               You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
-               Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-               The block contains the following arguments:
         """
         if enabled is not None:
             pulumi.set(__self__, "enabled", enabled)
@@ -5114,11 +5109,6 @@ class ServiceAutoPauseNotificationsParameters(dict):
     def timeout(self) -> Optional[int]:
         """
         Indicates in seconds how long alerts should be suspended before triggering. Allowed values: `120`, `180`, `300`, `600`, `900` if `enabled` is `true`. Must be omitted or set to `null` if `enabled` is `false`.
-
-
-        You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
-        Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.
-        The block contains the following arguments:
         """
         return pulumi.get(self, "timeout")
 
@@ -5885,7 +5875,10 @@ class ServiceIncidentUrgencyRule(dict):
                  outside_support_hours: Optional['outputs.ServiceIncidentUrgencyRuleOutsideSupportHours'] = None,
                  urgency: Optional[str] = None):
         """
-        :param str type: The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        :param str type: The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).
+        :param 'ServiceIncidentUrgencyRuleDuringSupportHoursArgs' during_support_hours: Incidents' urgency during support hours.
+        :param 'ServiceIncidentUrgencyRuleOutsideSupportHoursArgs' outside_support_hours: Incidents' urgency outside support hours.
+        :param str urgency: The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.
         """
         pulumi.set(__self__, "type", type)
         if during_support_hours is not None:
@@ -5899,23 +5892,32 @@ class ServiceIncidentUrgencyRule(dict):
     @pulumi.getter
     def type(self) -> str:
         """
-        The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        The type of incident urgency: `constant` or `use_support_hours` (when depending on specific support hours; see `support_hours`).
         """
         return pulumi.get(self, "type")
 
     @property
     @pulumi.getter(name="duringSupportHours")
     def during_support_hours(self) -> Optional['outputs.ServiceIncidentUrgencyRuleDuringSupportHours']:
+        """
+        Incidents' urgency during support hours.
+        """
         return pulumi.get(self, "during_support_hours")
 
     @property
     @pulumi.getter(name="outsideSupportHours")
     def outside_support_hours(self) -> Optional['outputs.ServiceIncidentUrgencyRuleOutsideSupportHours']:
+        """
+        Incidents' urgency outside support hours.
+        """
         return pulumi.get(self, "outside_support_hours")
 
     @property
     @pulumi.getter
     def urgency(self) -> Optional[str]:
+        """
+        The urgency: `low` Notify responders (does not escalate), `high` (follows escalation rules) or `severity_based` Set's the urgency of the incident based on the severity set by the triggering monitoring tool.
+        """
         return pulumi.get(self, "urgency")
 
 
@@ -6388,7 +6390,9 @@ class ServiceScheduledAction(dict):
                  to_urgency: Optional[str] = None,
                  type: Optional[str] = None):
         """
-        :param str type: The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        :param Sequence['ServiceScheduledActionAtArgs'] ats: A block representing when the scheduled action will occur.
+        :param str to_urgency: The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+        :param str type: The type of scheduled action. Currently, this must be set to `urgency_change`.
         """
         if ats is not None:
             pulumi.set(__self__, "ats", ats)
@@ -6400,18 +6404,24 @@ class ServiceScheduledAction(dict):
     @property
     @pulumi.getter
     def ats(self) -> Optional[Sequence['outputs.ServiceScheduledActionAt']]:
+        """
+        A block representing when the scheduled action will occur.
+        """
         return pulumi.get(self, "ats")
 
     @property
     @pulumi.getter(name="toUrgency")
     def to_urgency(self) -> Optional[str]:
+        """
+        The urgency to change to: `low` (does not escalate), or `high` (follows escalation rules).
+        """
         return pulumi.get(self, "to_urgency")
 
     @property
     @pulumi.getter
     def type(self) -> Optional[str]:
         """
-        The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        The type of scheduled action. Currently, this must be set to `urgency_change`.
         """
         return pulumi.get(self, "type")
 
@@ -6575,7 +6585,12 @@ class ServiceSupportHours(dict):
                  time_zone: Optional[str] = None,
                  type: Optional[str] = None):
         """
-        :param str type: The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        :param Sequence[int] days_of_weeks: Array of days of week as integers. `1` to `7`, `1` being
+               Monday and `7` being Sunday.
+        :param str end_time: The support hours' ending time of day.
+        :param str start_time: The support hours' starting time of day.
+        :param str time_zone: The time zone for the support hours.
+        :param str type: The type of support hours. Can be `fixed_time_per_day`.
         """
         if days_of_weeks is not None:
             pulumi.set(__self__, "days_of_weeks", days_of_weeks)
@@ -6591,28 +6606,41 @@ class ServiceSupportHours(dict):
     @property
     @pulumi.getter(name="daysOfWeeks")
     def days_of_weeks(self) -> Optional[Sequence[int]]:
+        """
+        Array of days of week as integers. `1` to `7`, `1` being
+        Monday and `7` being Sunday.
+        """
         return pulumi.get(self, "days_of_weeks")
 
     @property
     @pulumi.getter(name="endTime")
     def end_time(self) -> Optional[str]:
+        """
+        The support hours' ending time of day.
+        """
         return pulumi.get(self, "end_time")
 
     @property
     @pulumi.getter(name="startTime")
     def start_time(self) -> Optional[str]:
+        """
+        The support hours' starting time of day.
+        """
         return pulumi.get(self, "start_time")
 
     @property
     @pulumi.getter(name="timeZone")
     def time_zone(self) -> Optional[str]:
+        """
+        The time zone for the support hours.
+        """
         return pulumi.get(self, "time_zone")
 
     @property
     @pulumi.getter
     def type(self) -> Optional[str]:
         """
-        The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+        The type of support hours. Can be `fixed_time_per_day`.
         """
         return pulumi.get(self, "type")
 


### PR DESCRIPTION
Due to [somewhat nonstandard](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service) block descriptions, we were omitting some fields on pagerduty.Service doc.

This pull request adds a docEdit rule that strips all of the extraneous text from the nested block description and rewrites it to reflect the nested blocks format the bridge expects.

This fixes field descriptions for `ServiceSupportHours`, `ServiceScheduledAction`, and `ServiceIncidentUrgencyRule` nested blocks.

Note that this PR is also build off of latest bridge rather than a release, to incorporate the much larger markdown parsing changes made in https://github.com/pulumi/pulumi-terraform-bridge/pull/2006.

Further note that this PR drops the additional information contained in the irregular block descriptions. This is the current status quo for all Pulumi providers. We additionally do not currently render extra information in the nested properties sections. 

Closes #477.

