### PR TITLE
fix: marshaling for useAppOauthScopedToken provider configuration

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -93,6 +93,16 @@ func Provider() tfbridge.ProviderInfo {
 					Value: false,
 				},
 			},
+			"use_app_oauth_scoped_token": {
+				MaxItemsOne: tfbridge.True(),
+				Elem: &tfbridge.SchemaInfo{
+					Fields: map[string]*tfbridge.SchemaInfo{
+						"pd_client_id":     {Name: "pdClientId"},
+						"pd_client_secret": {Name: "pdClientSecret"},
+						"pd_subdomain":     {Name: "pdSubdomain"},
+					},
+				},
+			},
 		},
 		UpstreamRepoPath: "./upstream",
 		Resources: map[string]*tfbridge.ResourceInfo{

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -95,13 +95,6 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"use_app_oauth_scoped_token": {
 				MaxItemsOne: tfbridge.True(),
-				Elem: &tfbridge.SchemaInfo{
-					Fields: map[string]*tfbridge.SchemaInfo{
-						"pd_client_id":     {Name: "pdClientId"},
-						"pd_client_secret": {Name: "pdClientSecret"},
-						"pd_subdomain":     {Name: "pdSubdomain"},
-					},
-				},
 			},
 		},
 		UpstreamRepoPath: "./upstream",


### PR DESCRIPTION
### Summary

This PR fixes https://github.com/pulumi/pulumi-pagerduty/issues/569. It seems that the `useAppOauthScopedToken` provider configuration option is being passed as nil to the underlying Terraform provider variable `use_app_oauth_scoped_token`. I think this was likely due to a change between 4.8.1 and 4.9.0 that switches the Pulumi provider to be a muxed provider (`pftfbridge.MainWithMuxer`), the upstream provider is also muxed and the bridge is a bit conservative and sends an Object while the SDKv2 part of the provider is still looking for a list of length 1.

### Changes

* `provider/resources.go`: Explicitly mapped the `use_app_oauth_scoped_token` configuration field.
  * Defined explicit Fields mapping for `pd_client_id`, `pd_client_secret`, and `pd_subdomain` to ensure consistent camelCase to snake_case translation.
* Added `MaxItemsOne: tfbridge.True()` to ensure the Pulumi object is correctly wrapped into a single-element list before being passed to the Terraform provider.

There were no changes to `bridge-metadata.json` when `make tfgen` was run.

### Testing

Tested locally by building the provider and using PULUMI_DEBUG_PROVIDERS with a NodeJS consumer project after running `npm install $PROJECT_DIR/sdk/nodejs` that was previously using v4.8.1.

Upgrading to 4.9.0 and above would cause the following error (also in the issue above):

```
    error: Cannot obtain plugin client:
    No valid credentials found for PagerDuty provider.
    Please see https://www.terraform.io/docs/providers/pagerduty/index.html
    for more information on providing credentials for this provider.
```

I was able to deploy a new set of resources for a debug service we usually do not deploy and then remove them without issue.