### PR TITLE
[shadow] fix: marshaling for useAppOauthScopedToken provider configuration

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -93,6 +93,16 @@ func Provider() tfbridge.ProviderInfo {
 					Value: false,
 				},
 			},
+			"use_app_oauth_scoped_token": {
+				MaxItemsOne: tfbridge.True(),
+				Elem: &tfbridge.SchemaInfo{
+					Fields: map[string]*tfbridge.SchemaInfo{
+						"pd_client_id":     {Name: "pdClientId"},
+						"pd_client_secret": {Name: "pdClientSecret"},
+						"pd_subdomain":     {Name: "pdSubdomain"},
+					},
+				},
+			},
 		},
 		UpstreamRepoPath: "./upstream",
 		Resources: map[string]*tfbridge.ResourceInfo{

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -95,13 +95,6 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"use_app_oauth_scoped_token": {
 				MaxItemsOne: tfbridge.True(),
-				Elem: &tfbridge.SchemaInfo{
-					Fields: map[string]*tfbridge.SchemaInfo{
-						"pd_client_id":     {Name: "pdClientId"},
-						"pd_client_secret": {Name: "pdClientSecret"},
-						"pd_subdomain":     {Name: "pdSubdomain"},
-					},
-				},
 			},
 		},
 		UpstreamRepoPath: "./upstream",


### PR DESCRIPTION
Shadow of #1028 — same commit (2ad15432), re-pushed under a pulumi/pulumi-pagerduty branch so CI runs on it.

Original PR: #1028 by @gunzy83
Original issue: #569

Opened to verify the fix's CI state; not intended to supersede #1028. Will close once we've confirmed the signal.